### PR TITLE
avoid slice bounds out of range of LooksLikeFormat function

### DIFF
--- a/media_parser.go
+++ b/media_parser.go
@@ -97,7 +97,7 @@ func (pmp *PngMediaParser) ParseBytes(data []byte) (mc riimage.MediaContext, err
 // LooksLikeFormat returns a boolean indicating whether the stream looks like a
 // PNG image.
 func (pmp *PngMediaParser) LooksLikeFormat(data []byte) bool {
-    return bytes.Compare(data[:len(PngSignature)], PngSignature[:]) == 0
+    return len(data) >= len(PngSignature) && bytes.Compare(data[:len(PngSignature)], PngSignature[:]) == 0
 }
 
 var (


### PR DESCRIPTION
When we use a "picture" that is smaller than the length of PngSignature, the index is out of bounds due to the direct use of the index in the LooksLikeFormat function:

```
func (pmp *PngMediaParser) LooksLikeFormat(data []byte) bool {
	return bytes.Compare(data[:len(PngSignature)], PngSignature[:]) == 0
	// len(data) is smaller than len(PngSignature)
}
```